### PR TITLE
Feat/sw lee2973/#14: 하단 네비게이션 바 구현

### DIFF
--- a/src/assets/common/menuBar/feed-select.svg
+++ b/src/assets/common/menuBar/feed-select.svg
@@ -1,0 +1,13 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_836_6310)">
+<path d="M10 3H3V10H10V3Z" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 3H14V10H21V3Z" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 14H14V21H21V14Z" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 14H3V21H10V14Z" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_836_6310">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/common/menuBar/feed.svg
+++ b/src/assets/common/menuBar/feed.svg
@@ -1,0 +1,13 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_836_6304)">
+<path d="M10 3H3V10H10V3Z" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 3H14V10H21V3Z" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 14H14V21H21V14Z" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 14H3V21H10V14Z" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_836_6304">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/common/menuBar/group-select.svg
+++ b/src/assets/common/menuBar/group-select.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="users">
+<path id="Vector" d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M9 11C11.2091 11 13 9.20914 13 7C13 4.79086 11.2091 3 9 3C6.79086 3 5 4.79086 5 7C5 9.20914 6.79086 11 9 11Z" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M23 20.9999V18.9999C22.9993 18.1136 22.7044 17.2527 22.1614 16.5522C21.6184 15.8517 20.8581 15.3515 20 15.1299" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_4" d="M16 3.12988C16.8604 3.35018 17.623 3.85058 18.1676 4.55219C18.7122 5.2538 19.0078 6.11671 19.0078 7.00488C19.0078 7.89305 18.7122 8.75596 18.1676 9.45757C17.623 10.1592 16.8604 10.6596 16 10.8799" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/assets/common/menuBar/group.svg
+++ b/src/assets/common/menuBar/group.svg
@@ -1,0 +1,13 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_836_6282)">
+<path d="M17 21V19C17 17.9391 16.5786 16.9217 15.8284 16.1716C15.0783 15.4214 14.0609 15 13 15H5C3.93913 15 2.92172 15.4214 2.17157 16.1716C1.42143 16.9217 1 17.9391 1 19V21" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 11C11.2091 11 13 9.20914 13 7C13 4.79086 11.2091 3 9 3C6.79086 3 5 4.79086 5 7C5 9.20914 6.79086 11 9 11Z" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M23 20.9999V18.9999C22.9993 18.1136 22.7044 17.2527 22.1614 16.5522C21.6184 15.8517 20.8581 15.3515 20 15.1299" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 3.12988C16.8604 3.35018 17.623 3.85058 18.1676 4.55219C18.7122 5.2538 19.0078 6.11671 19.0078 7.00488C19.0078 7.89305 18.7122 8.75596 18.1676 9.45757C17.623 10.1592 16.8604 10.6596 16 10.8799" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_836_6282">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/common/menuBar/home-select.svg
+++ b/src/assets/common/menuBar/home-select.svg
@@ -1,0 +1,15 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_836_6258)">
+<path d="M9 22H5C4.46957 22 3.96086 21.7893 3.58579 21.4142C3.21071 21.0391 3 20.5304 3 20V9L12 2L21 9V20C21 20.5304 20.7893 21.0391 20.4142 21.4142C20.0391 21.7893 19.5304 22 19 22H15" stroke="#145044" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 22V12H15V22" stroke="#145044" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 2L20.6603 9.5H3.33975L12 2Z" fill="#145044"/>
+<rect x="3" y="9" width="18" height="6" fill="#145044"/>
+<rect x="3" y="11" width="6" height="11" rx="1" fill="#145044"/>
+<rect x="15" y="11" width="6" height="11" rx="1" fill="#145044"/>
+</g>
+<defs>
+<clipPath id="clip0_836_6258">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/common/menuBar/home.svg
+++ b/src/assets/common/menuBar/home.svg
@@ -1,0 +1,15 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_836_1890)">
+<path d="M9 22H5C4.46957 22 3.96086 21.7893 3.58579 21.4142C3.21071 21.0391 3 20.5304 3 20V9L12 2L21 9V20C21 20.5304 20.7893 21.0391 20.4142 21.4142C20.0391 21.7893 19.5304 22 19 22H15" stroke="#A3A3A3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 22V12H15V22" stroke="#A3A3A3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 2L20.6603 9.5H3.33975L12 2Z" fill="#A3A3A3"/>
+<rect x="3" y="9" width="18" height="6" fill="#A3A3A3"/>
+<rect x="3" y="11" width="6" height="11" rx="1" fill="#A3A3A3"/>
+<rect x="15" y="11" width="6" height="11" rx="1" fill="#A3A3A3"/>
+</g>
+<defs>
+<clipPath id="clip0_836_1890">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/common/menuBar/mypage-select.svg
+++ b/src/assets/common/menuBar/mypage-select.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="smile">
+<path id="Vector" d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M8 14C8 14 9.5 16 12 16C14.5 16 16 14 16 14" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M9 9H9.01" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_4" d="M15 9H15.01" stroke="#145044" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/assets/common/menuBar/mypage.svg
+++ b/src/assets/common/menuBar/mypage.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="smile">
+<path id="Vector" d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M8 14C8 14 9.5 16 12 16C14.5 16 16 14 16 14" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M9 9H9.01" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_4" d="M15 9H15.01" stroke="#A3A3A3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/components/atom/common/MainMenuList.js
+++ b/src/components/atom/common/MainMenuList.js
@@ -1,0 +1,22 @@
+export const MENU_LIST = [
+  {
+    name: '홈',
+    path: '/',
+    icon: { default: 'home.svg', select: 'home-select.svg' },
+  },
+  {
+    name: '모임',
+    path: '/group',
+    icon: { default: 'group.svg', select: 'group-select.svg' },
+  },
+  {
+    name: '피드',
+    path: '/feed',
+    icon: { default: 'feed.svg', select: 'feed-select.svg' },
+  },
+  {
+    name: '마이페이지',
+    path: '/mypage',
+    icon: { default: 'mypage.svg', select: 'mypage-select.svg' },
+  },
+];

--- a/src/components/atom/common/MainNavItem.jsx
+++ b/src/components/atom/common/MainNavItem.jsx
@@ -1,0 +1,26 @@
+import { useLocation } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
+
+const MainNavItem = ({ item }) => {
+  const location = useLocation();
+  const currentPage = '/' + location.pathname.split('/')[1];
+
+  return (
+    <NavLink to={item.path}>
+      <figure className="flex w-10 flex-col items-center">
+        <img
+          className="size-6"
+          src={`/src/assets/common/menubar/${currentPage === item.path ? item.icon.select : item.icon.default}`}
+          alt=""
+        />
+        <figcaption
+          className={`w-15 text-nowrap font-Gong-Gothic-l ${currentPage === item.path ? 'text-primary-color' : 'text-gray500'}`}
+        >
+          {item.name}
+        </figcaption>
+      </figure>
+    </NavLink>
+  );
+};
+
+export default MainNavItem;

--- a/src/components/molecule/common/MainNavBar.jsx
+++ b/src/components/molecule/common/MainNavBar.jsx
@@ -1,0 +1,17 @@
+import MainNavItem from '@/components/atom/common/MainNavItem';
+import { MENU_LIST } from '@/components/atom/common/MainMenuList';
+
+const MainNavBar = () => {
+  return (
+    <section className="mobile:w-full fixed bottom-0 flex h-[95px] w-[430px] justify-center px-[45px] pb-[35px] pt-5 shadow-[0_-4px_4px_0_rgba(204,204,204,0.25)]">
+      <h2 className="sr-only">메인 네비게이션</h2>
+      <div className="flex h-[42px] w-[340px] items-center justify-between">
+        {MENU_LIST.map((item) => (
+          <MainNavItem key={item.name} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default MainNavBar;

--- a/src/pages/FeedTest.jsx
+++ b/src/pages/FeedTest.jsx
@@ -1,0 +1,5 @@
+export const Component = () => {
+  return <div>피드임</div>;
+};
+
+Component.displayName = 'feed';

--- a/src/pages/GroupTest.jsx
+++ b/src/pages/GroupTest.jsx
@@ -1,0 +1,5 @@
+export const Component = () => {
+  return <div>모임임</div>;
+};
+
+Component.displayName = 'group';

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,3 +1,4 @@
+import MainNavBar from '@/components/molecule/common/MainNavBar';
 import { Outlet } from 'react-router-dom';
 
 const Layout = () => {
@@ -9,6 +10,7 @@ const Layout = () => {
         </section>
         <div className=" mobile:w-screen w-[430px] min-w-[372px] bg-white">
           <Outlet />
+          <MainNavBar />
         </div>
       </div>
     </main>

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,0 +1,12 @@
+import { Outlet } from 'react-router-dom';
+
+export const Component = () => {
+  return (
+    <div>
+      마이페이지임
+      <Outlet />
+    </div>
+  );
+};
+
+Component.displayName = 'mypage';

--- a/src/routes/navigation.jsx
+++ b/src/routes/navigation.jsx
@@ -1,3 +1,5 @@
+import Test from '@/components/organism/mypage/Test';
+
 const navigationItems = [
   {
     id: 'main',
@@ -10,15 +12,31 @@ const navigationItems = [
     id: 'login',
     path: '/login',
     text: '로그인 화면',
-    // element: <Login />,
     lazy: () => import('@/pages/Login'),
   },
   {
     id: 'register',
     path: '/register',
     text: '회원가입 화면',
-    // element: <Register />,
     lazy: () => import('@/pages/Register'),
+  },
+  {
+    id: 'group',
+    path: '/group',
+    text: '모임 화면',
+    lazy: () => import('@/pages/GroupTest'),
+  },
+  {
+    id: 'feed',
+    path: '/feed',
+    text: '피드 화면',
+    lazy: () => import('@/pages/FeedTest'),
+  },
+  {
+    id: 'mypage',
+    path: '/mypage',
+    text: '마이페이지 화면',
+    lazy: () => import('@/pages/MyPage'),
   },
 ];
 

--- a/src/routes/navigation.jsx
+++ b/src/routes/navigation.jsx
@@ -1,5 +1,3 @@
-import Test from '@/components/organism/mypage/Test';
-
 const navigationItems = [
   {
     id: 'main',


### PR DESCRIPTION

### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
하단 네비게이션 바 구현

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- 네비게이션 메뉴 마크업
- 네비게이션 컴포넌트 쪼개기
- 네비게이션 메뉴 클릭 시 해당하는 페이지 이동
- 페이지에 맞는 액티브 스타일 구현

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- NavLink의 활성 메뉴 아이콘 스타일 적용

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
- isActive 뿐 아닌 useLocation을 사용한 활성화 아이콘 스타일 적용 방법

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|네비게이션 바|![02 29  하단 네비게이션 바 구현](https://github.com/FRONTENDSCHOOL8/dosirak/assets/46062634/d3e092da-20df-49e7-858e-e3bf04bd91a4)|