### PR TITLE
[Feat] 03/05 SWLee2973 피드 데이터 분류 및 정렬 #28

### DIFF
--- a/src/pages/Feed.jsx
+++ b/src/pages/Feed.jsx
@@ -1,9 +1,11 @@
+import Spinner from '@/components/atom/common/Spinner';
 import MainNavBar from '@/components/molecule/common/MainNavBar';
 import NavBar from '@/components/molecule/navbar/NavBar';
 import FeedCard from '@/components/organism/feed/FeedCard';
 import { getPbImage, pb } from '@/util';
 import { getPbImageArray } from '@/util/getPbImage';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
 import { Outlet } from 'react-router-dom';
 import { useLoaderData } from 'react-router-dom';
 
@@ -19,24 +21,31 @@ const feedPath = [
 
 export const Component = () => {
   const loadedFeedsData = useLoaderData();
+  const { feedType } = useParams();
+  const queryOptions = setQueryOptions(feedType);
 
   const {
     data: cachedFeedsData,
     hasNextPage,
     fetchNextPage,
+    status,
   } = useInfiniteQuery({
     ...queryOptions,
     initialData: loadedFeedsData,
     staleTime: 1000 * 5,
   });
 
-  const feedsData = cachedFeedsData ? cachedFeedsData.pages : [];
+  console.log(loadedFeedsData);
 
+  const feedsData = cachedFeedsData ? cachedFeedsData.pages : [];
+  console.log(feedsData);
   const feedItems = feedsData
     .map((feedsData) => feedsData.items)
     .flatMap((feedItems) => feedItems);
 
-  return (
+  return status === 'loading' ? (
+    <Spinner textArray={['탕수육 만드는중...', '레시피 찾는중...']} />
+  ) : (
     <>
       <section className="relative flex h-fit min-h-screen flex-col">
         <h2 className="sr-only">피드</h2>
@@ -57,13 +66,27 @@ export const Component = () => {
   );
 };
 
-const fetchFeeds = async (pageInfo) => {
-  console.log(pageInfo);
+const fetchFeeds = (feedType) => async (pageInfo) => {
+  const currentUserId = JSON.parse(localStorage.getItem('pocketbase_auth'))
+    ?.model.id;
+
+  const collection = {
+    popular: { collection: 'feed_popular', sortField: 'i_like_it', filter: '' },
+    recommend: { collection: 'feed', sortField: 'id', filter: '' },
+    following: {
+      collection: 'feed',
+      sortField: 'created',
+      filter: `writer.follower.id ?= "${currentUserId}"`,
+    },
+    myfeed: { collection: 'feed', sortField: 'created', filter: '' },
+  };
+
   const feeds = await pb
-    .collection('feed')
+    .collection(collection[feedType].collection)
     .getList(pageInfo.pageParam, PER_PAGE, {
-      sort: '-created',
+      sort: `-${collection[feedType].sortField}`,
       expand: 'writer, like, bookmark',
+      filter: collection[feedType].filter,
     });
 
   const feedItems = feeds.items.map((feed) => {
@@ -81,14 +104,14 @@ const fetchFeeds = async (pageInfo) => {
   };
 };
 
-const queryOptions = {
-  queryKey: ['feed'],
-  queryFn: fetchFeeds,
+const setQueryOptions = (feedType) => ({
+  queryKey: ['feed', feedType],
+  queryFn: fetchFeeds(feedType),
   initialPageParam: INITIAL_PAGE,
   getNextPageParam: (lastPage, allPages) => {
     return lastPage.page < lastPage.totalPages ? allPages.length + 1 : null;
   },
-};
+});
 
 export const loader =
   (queryClient) =>
@@ -96,6 +119,8 @@ export const loader =
     const { feedType } = params;
     let feedsData = null;
     const cachedFeedsData = queryClient.getQueryData(['feed']);
+
+    const queryOptions = setQueryOptions(feedType);
 
     // 캐싱된 피드 데이터가 있을 경우
     if (cachedFeedsData) {


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#28 피드 데이터 분류 및 정렬

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- 피드 분류 별 정렬 표시
- 팔로잉 탭은 팔로우한 유저의 피드만 표시
 
### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- pocketbase의 view 컬렉션 활용
- 분류된 페이지 param 별 collection, sortField, filter 활용

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
- pocketbase의 feed_popular view collection

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|탭 별 피드 표시|![03 05  인기,추천,팔로잉 피드 분류 별 표시](https://github.com/FRONTENDSCHOOL8/dosirak/assets/46062634/efaf2b80-fe6d-4c91-8a41-6e4959a1cca4)|