### PR TITLE
[Feat] 03/09 SWLee2973 로그인 동작 변경 #36: 중간 PR 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "5",
+    "@tanstack/react-query-devtools": "^5.25.0",
     "@tinymce/tinymce-react": "^4.3.2",
     "gsap": "^3.12.5",
     "pocketbase": "^0.21.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@tanstack/react-query':
     specifier: '5'
     version: 5.22.2(react@18.2.0)
+  '@tanstack/react-query-devtools':
+    specifier: ^5.25.0
+    version: 5.25.0(@tanstack/react-query@5.22.2)(react@18.2.0)
   '@tinymce/tinymce-react':
     specifier: ^4.3.2
     version: 4.3.2(react-dom@18.2.0)(react@18.2.0)
@@ -3798,6 +3801,21 @@ packages:
 
   /@tanstack/query-core@5.22.2:
     resolution: {integrity: sha512-z3PwKFUFACMUqe1eyesCIKg3Jv1mysSrYfrEW5ww5DCDUD4zlpTKBvUDaEjsfZzL3ULrFLDM9yVUxI/fega1Qg==}
+    dev: false
+
+  /@tanstack/query-devtools@5.24.0:
+    resolution: {integrity: sha512-pThim455t69zrZaQKa7IRkEIK8UBTS+gHVAdNfhO72Xh4rWpMc63ovRje5/n6iw63+d6QiJzVadsJVdPoodSeQ==}
+    dev: false
+
+  /@tanstack/react-query-devtools@5.25.0(@tanstack/react-query@5.22.2)(react@18.2.0):
+    resolution: {integrity: sha512-bqtr1Bwvo/jspJXb2l4R1DSZ848TvIzGBk4V0b6YGS5EQ3015dhm3mPqyTgh0DquK5ZR0h1yP/4DpzhhvTnFHA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.25.0
+      react: ^18.0.0
+    dependencies:
+      '@tanstack/query-devtools': 5.24.0
+      '@tanstack/react-query': 5.22.2(react@18.2.0)
+      react: 18.2.0
     dev: false
 
   /@tanstack/react-query@5.22.2(react@18.2.0):

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { HelmetProvider } from 'react-helmet-async';
 import router from '@/routes';
 import { RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -14,6 +15,7 @@ export const queryClient = new QueryClient({
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={true} />
       <HelmetProvider>
         <RouterProvider router={router} />
       </HelmetProvider>

--- a/src/components/atom/common/LoginUserThumbnail.jsx
+++ b/src/components/atom/common/LoginUserThumbnail.jsx
@@ -3,14 +3,13 @@ import useCommonStore from '@/store/useCommonStore';
 import { memo } from 'react';
 
 const LoginUserThumbnail = ({ thumbnailCaption }) => {
-  const { loginUser } = useCommonStore((state) => state);
-  useLoginUserInfo();
+  const userInfo = useLoginUserInfo();
 
   return (
     <figure className="size-full">
       <img
         className="size-full select-none rounded-full border-[0.5px]"
-        src={loginUser.thumbnail}
+        src={userInfo.thumbnail}
         alt=""
       />
       <figcaption className="sr-only">{thumbnailCaption}</figcaption>

--- a/src/components/molecule/feed/FeedInteraction.jsx
+++ b/src/components/molecule/feed/FeedInteraction.jsx
@@ -1,11 +1,10 @@
 import { ReactComponent as Comment } from '@/assets/common/comment.svg';
 import ToggleButton from '@/components/atom/common/ToggleButton';
+import { useLoginUserInfo } from '@/hook';
 import useFeedStore from '@/store/useFeedStore';
-import { getLoginUserId, pb } from '@/util';
+import { pb } from '@/util';
 import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-
-const currentUserId = getLoginUserId();
 
 const fetchInteraction = async (feedId, data) => {
   const result = await pb.collection('feed').update(feedId, data);
@@ -17,15 +16,16 @@ const FeedInteraction = ({ feed }) => {
   const { feedType } = useParams();
   const [currentBookmark, setCurrentBookmark] = useState(feed.bookmark);
   const [currentLikeIt, setCurrentLikeIt] = useState(feed.like);
+  const userInfo = useLoginUserInfo();
 
   const handleOpenCommentWindow = () => {
     setCommentView(feed.id);
   };
 
   const handleBookmark = () => {
-    const nextBookmark = currentBookmark.includes(currentUserId)
-      ? currentBookmark.filter((v) => v != currentUserId)
-      : [...currentBookmark, currentUserId];
+    const nextBookmark = currentBookmark.includes(userInfo.id)
+      ? currentBookmark.filter((v) => v != userInfo.id)
+      : [...currentBookmark, userInfo.id];
 
     setCurrentBookmark(nextBookmark);
 
@@ -37,9 +37,9 @@ const FeedInteraction = ({ feed }) => {
   };
 
   const handleLikeIt = () => {
-    const nextLikeIt = currentLikeIt.includes(currentUserId)
-      ? currentLikeIt.filter((v) => v != currentUserId)
-      : [...currentLikeIt, currentUserId];
+    const nextLikeIt = currentLikeIt.includes(userInfo.id)
+      ? currentLikeIt.filter((v) => v != userInfo.id)
+      : [...currentLikeIt, userInfo.id];
 
     setCurrentLikeIt(nextLikeIt);
 
@@ -65,7 +65,7 @@ const FeedInteraction = ({ feed }) => {
           type="heart"
           alt="좋아요"
           colorType="black"
-          isClicked={currentLikeIt.includes(currentUserId)}
+          isClicked={currentLikeIt.includes(userInfo.id)}
         />
         <span className='select-none rounded-lg bg-[url("@/assets/common/likeinfo.svg")] bg-cover bg-no-repeat py-1.5 pe-3 ps-5 text-paragraph-base'>
           {currentLikeIt.length}명이 좋아합니다.
@@ -75,7 +75,7 @@ const FeedInteraction = ({ feed }) => {
         onClickButton={handleBookmark}
         type="bookmark"
         alt="북마크"
-        isClicked={currentBookmark.includes(currentUserId)}
+        isClicked={currentBookmark.includes(userInfo.id)}
       />
     </section>
   );

--- a/src/components/molecule/feed/FeedWriteHeader.jsx
+++ b/src/components/molecule/feed/FeedWriteHeader.jsx
@@ -2,7 +2,7 @@ const FeedWriteHeader = ({ handleBack }) => {
   return (
     <header className="fixed top-0 z-10 w-[430px] bg-white shadow-[0_4px_4px_0_rgba(204,204,204,0.25)] mobile:w-full">
       <div className="relative flex h-20 items-center gap-3 px-6">
-        <button onClick={handleBack} className="absolute left-6">
+        <button type="button" onClick={handleBack} className="absolute left-6">
           <img src="/assets/common/prev.svg" alt="뒤로 가기" />
         </button>
         <span className="noto flex-grow text-center text-heading-sm font-semibold">

--- a/src/components/molecule/feed/FeedWriter.jsx
+++ b/src/components/molecule/feed/FeedWriter.jsx
@@ -1,8 +1,8 @@
 import ToggleButton from '@/components/atom/common/ToggleButton';
-import { getDate, getLoginUserId, pb } from '@/util';
+import { useLoginUserInfo } from '@/hook';
+import useCommonStore from '@/store/useCommonStore';
+import { getDate, pb } from '@/util';
 import { useState } from 'react';
-
-const currentUserId = getLoginUserId();
 
 const fetchInteraction = async (userId, data) => {
   const result = await pb.collection('users').update(userId, data);
@@ -14,18 +14,21 @@ const FeedWriter = ({ feed, refetch }) => {
     feed.expand.writer.follower
   );
 
+  const userInfo = useLoginUserInfo();
+  const writerId = feed.expand.writer.id;
+
   const handleFollow = () => {
-    const nextFollower = currentFollower.includes(currentUserId)
-      ? currentFollower.filter((v) => v != currentUserId)
-      : [...currentFollower, currentUserId];
+    const nextFollower = currentFollower.includes(userInfo.id)
+      ? currentFollower.filter((v) => v != userInfo.id)
+      : [...currentFollower, userInfo.id];
 
     setCurrentFollower(nextFollower);
 
-    const data = {
+    const followerData = {
       follower: nextFollower,
     };
 
-    fetchInteraction(feed.expand.writer.id, data);
+    fetchInteraction(writerId, followerData);
     refetch();
   };
 
@@ -47,10 +50,10 @@ const FeedWriter = ({ feed, refetch }) => {
       <ToggleButton
         onClickButton={handleFollow}
         type="follow"
-        alt={currentFollower.includes(currentUserId) ? '팔로잉' : '팔로우'}
-        isClicked={currentFollower.includes(currentUserId)}
+        alt={userInfo.follow.includes(writerId) ? '팔로잉' : '팔로우'}
+        isClicked={userInfo.follow.includes(writerId)}
       >
-        {currentFollower.includes(currentUserId) ? '팔로잉' : '팔로우'}
+        {userInfo.follow.includes(writerId) ? '팔로잉' : '팔로우'}
       </ToggleButton>
     </div>
   );

--- a/src/components/molecule/login/LoginInput.jsx
+++ b/src/components/molecule/login/LoginInput.jsx
@@ -9,7 +9,7 @@ const LoginInput = ({ children, name, updater, value, ...restProps }) => {
       <input
         name={name}
         id={name}
-        className="noto h-11 w-full rounded-[5px] border-2 border-gray300 px-3 text-paragraph-base outline-none focus:border-primary-color"
+        className="noto h-11 w-full rounded-[5px] border-2 border-gray300 px-3 text-paragraph-lg outline-none focus:border-primary-color"
         {...restProps}
         onChange={debounce(updater, 100)}
         defaultValue={value}

--- a/src/hook/useLoginUserInfo.js
+++ b/src/hook/useLoginUserInfo.js
@@ -1,24 +1,23 @@
-import useCommonStore from '@/store/useCommonStore';
-import { getPbImage } from '@/util';
-import { useEffect } from 'react';
+import useUserPersistStore from '@/store/useUserPersistStore';
+import useUserSessionStore from '@/store/useUserSessionStore';
+import { useLayoutEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-const useLoginUserInfo = (callbackFn) => {
-  const { loginUser, setLoginUser } = useCommonStore((state) => state);
+const useLoginUserInfo = () => {
+  const { loginUser: sessionUser } = useUserSessionStore((state) => state);
+  const { loginUser: rememberUser } = useUserPersistStore((state) => state);
+  const navigate = useNavigate();
 
-  useEffect(() => {
-    const auth = JSON.parse(localStorage.getItem('pocketbase_auth'));
-    if (!loginUser.nickname && auth?.model.nickname) {
-      setLoginUser({
-        id: auth.model.id,
-        nickname: auth.model.nickname,
-        thumbnail: auth.model.thumbnail
-          ? getPbImage(auth.model)
-          : `${window.location.origin}/assets/common/guest.svg`,
-      });
+  const userInfo = Object.keys(sessionUser).length ? sessionUser : rememberUser;
+
+  useLayoutEffect(() => {
+    if (!Object.keys(userInfo).length) {
+      alert('로그인 후 이용 가능합니다.');
+      navigate('/login');
     }
-
-    callbackFn?.();
   }, []);
+
+  return userInfo;
 };
 
 export default useLoginUserInfo;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,7 +4,7 @@ import App from './App.jsx';
 import '@/styles/main.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  // <React.StrictMode>
+  <App />
+  // </React.StrictMode>
 );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,26 +1,14 @@
 import MainNavBar from '@/components/molecule/common/MainNavBar';
 import { useLoginUserInfo } from '@/hook';
-import useCommonStore from '@/store/useCommonStore';
-import { useNavigate } from 'react-router-dom';
 
 export const Component = () => {
-  const { loginUser } = useCommonStore((state) => state);
-  const navigate = useNavigate();
-
-  useLoginUserInfo(() => {
-    const auth = JSON.parse(localStorage.getItem('pocketbase_auth'));
-
-    if (!loginUser.nickname && !auth?.model.nickname) {
-      alert('로그인 후 이용 가능합니다.');
-      navigate('/login');
-    }
-  });
+  const userInfo = useLoginUserInfo();
 
   return (
     <>
       <section className="relative flex h-fit min-h-screen flex-col">
         <h2>홈</h2>
-        <span>{loginUser.nickname}님 안녕하세요!</span>
+        <span>{userInfo.nickname}님 안녕하세요!</span>
       </section>
       <MainNavBar />
     </>

--- a/src/store/useCommonStore.js
+++ b/src/store/useCommonStore.js
@@ -2,13 +2,11 @@ import { create } from 'zustand';
 
 const initialState = {
   isPending: false,
-  loginUser: {},
 };
 
 const createState = (set) => ({
   ...initialState,
 
-  setLoginUser: (value) => set(() => ({ loginUser: value })),
   setIsPending: (value) => set(() => ({ isPending: value })),
 });
 

--- a/src/store/useUserPersistStore.js
+++ b/src/store/useUserPersistStore.js
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+const initialState = {
+  loginUser: {},
+};
+
+const createState = persist(
+  (set) => ({
+    ...initialState,
+
+    setLoginUser: (value) => set(() => ({ loginUser: value })),
+  }),
+  {
+    name: 'loginUserInfo',
+  }
+);
+
+const useUserPersistStore = create(createState);
+
+export default useUserPersistStore;

--- a/src/store/useUserSessionStore.js
+++ b/src/store/useUserSessionStore.js
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+const initialState = {
+  loginUser: {},
+};
+
+const createState = persist(
+  (set) => ({
+    ...initialState,
+
+    setLoginUser: (value) => set(() => ({ loginUser: value })),
+  }),
+  {
+    name: 'loginUserInfo',
+    storage: createJSONStorage(() => sessionStorage),
+  }
+);
+
+const useUserSessionStore = create(createState);
+
+export default useUserSessionStore;


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#36 피드 글 쓰기 - 글쓴 이후 새게시글 조회 안됨 수정 관련

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- 로그인 시 zustand의 persist 적용
- 로그인 기억할 경우 및 기억하지 않을 경우 분기: useLoginUserInfo
- 앞으로의 로그인 사용자 정보는 session/localStorage 및 useLoginUserInfo의 return 값 사용 const userInfo = useLoginUserInfo() --> userInfo = { id: ..., thumbnail: ..., follow: ..., nickname: ... }
- 로그인 동작 로직 변경에 따른 Feed.jsx 코드 변경
- Tanstack Query DevTool 설치

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 로그인 상태 체크 시 useLoginUserInfo() 사용

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
- Tanstack Query DevTool 설치 -> `pnpm install` 필요

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|로그인 적용 방식 변경|스크린샷 없음|
