### PR TITLE
[Feat] 03/13 lanuioe 모임 가입하기 구현

### DIFF
--- a/src/components/organism/group/GroupListCard.jsx
+++ b/src/components/organism/group/GroupListCard.jsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 const GroupListCard = ({ group }) => {
   const { id, title, thumbnail, participant, like, hashTag, isRecruiting } =
     group;
-  const uploadTime = 3;
+  const uploadTime = 1;
 
   return (
     <li className="relative">

--- a/src/components/organism/group/GroupParticipate.jsx
+++ b/src/components/organism/group/GroupParticipate.jsx
@@ -1,0 +1,88 @@
+import { useLoginUserInfo } from '@/hook';
+import { pb } from '@/util';
+import { useState, useEffect, useRef } from 'react';
+
+const GroupParticipate = ({ groupId }) => {
+  const userInfo = useLoginUserInfo();
+  const userId = userInfo.id;
+
+  const [groupData, setGroupData] = useState(null);
+  const [showDialog, setShowDialog] = useState(false);
+
+  const dialogRef = useRef(null);
+
+  const baseButtonClass = 'w-full rounded-3xl py-2 text-label';
+
+  // 참여하고 있지 않은 모임에만 모달 띄워주기
+  useEffect(() => {
+    const fetchGroupData = async () => {
+      const data = await pb.collection('groups').getOne(groupId);
+      setGroupData(data);
+
+      if (!data.participant.includes(userId)) {
+        setShowDialog(true);
+        dialogRef.current.showModal();
+      }
+    };
+
+    fetchGroupData();
+  }, [groupId, userId]);
+
+  // 모달 닫기
+  useEffect(() => {
+    if (!showDialog && dialogRef.current) {
+      dialogRef.current.close();
+    }
+  }, [showDialog]);
+
+  const closePopup = () => {
+    setShowDialog(false);
+  };
+
+  const joinGroup = async (groupId, userId) => {
+    await updateGroupParticipant(groupId, userId);
+    alert('환영합니다! 모임에 가입되었습니다.');
+    setShowDialog(false);
+  };
+
+  const updateGroupParticipant = async (groupId, userId) => {
+    const updatedParticipants = [...groupData.participant, userId];
+    const updateData = {
+      participant: updatedParticipants,
+    };
+    await pb.collection('groups').update(groupId, updateData);
+    setGroupData({ ...groupData, participant: updatedParticipants }); // 로컬 상태 업데이트
+  };
+
+  return (
+    <section className="">
+      <h3 className="sr-only">모임 참여하기</h3>
+      {showDialog && (
+        <dialog
+          ref={dialogRef}
+          className="fixed z-10 h-[138px] w-[410px] rounded-xl bg-primary-color px-9 pb-6 pt-6"
+        >
+          <p className="font-Gong-Gothic-l text-heading-sm text-gray50">
+            모임이 마음에 드시나요?
+          </p>
+          <div className="mt-[18px] flex justify-between gap-4">
+            <button
+              className={`${baseButtonClass} bg-gray600 text-white`}
+              onClick={closePopup}
+            >
+              좀 더 볼래요
+            </button>
+            <button
+              className={`${baseButtonClass} bg-tertiary-color text-primary-color`}
+              onClick={() => joinGroup(groupId, userId)}
+            >
+              참여할래요
+            </button>
+          </div>
+        </dialog>
+      )}
+    </section>
+  );
+};
+
+export default GroupParticipate;

--- a/src/components/organism/group/GroupPopularCard.jsx
+++ b/src/components/organism/group/GroupPopularCard.jsx
@@ -10,7 +10,7 @@ import GroupInteraction from '@/components/atom/group/GroupInteraction';
 const GroupPopularCard = ({ group }) => {
   const { id, title, thumbnail, participant, like, hashTag, isRecruiting } =
     group;
-  const uploadTime = 3;
+  const uploadTime = 1;
 
   return (
     <li className="relative m-1 h-[280px] w-[280px]">

--- a/src/pages/Group.jsx
+++ b/src/pages/Group.jsx
@@ -86,7 +86,7 @@ export const Component = () => {
         <header>
           <NavBar path={groupPath}>모임</NavBar>
         </header>
-        <main className="mx-9">
+        <main className="mx-9 mb-12">
           {getGroupComponent(groupType, groupItems, likeItems)}
           <div ref={observeTarget} aria-hidden="true">
             &nbsp;

--- a/src/pages/GroupFeed.jsx
+++ b/src/pages/GroupFeed.jsx
@@ -3,6 +3,7 @@ import NoContents from '@/components/atom/common/NoContents';
 import MainNavBar from '@/components/molecule/common/MainNavBar';
 import NavBar from '@/components/molecule/navbar/NavBar';
 import FeedCard from '@/components/organism/feed/FeedCard';
+import GroupParticipate from '@/components/organism/group/GroupParticipate';
 import { useInterSectionObserver, useLoginUserInfo } from '@/hook';
 import { getPbImage, pb } from '@/util';
 import { getPbImageArray } from '@/util/getPbImage';
@@ -14,6 +15,7 @@ import {
   Outlet,
   useLoaderData,
   useNavigation,
+  Link,
 } from 'react-router-dom';
 
 const INITIAL_PAGE = 1;
@@ -73,7 +75,12 @@ export const Component = () => {
         <h2 className="sr-only">모임</h2>
         <header>
           <NavBar type="feed" path={groupFeedPath}>
-            모임
+            <div className="relative -left-[6px] flex items-center gap-3">
+              <Link to={-1}>
+                <img src="/assets/common/prev.svg" alt="뒤로가기" />
+              </Link>
+              모임
+            </div>
           </NavBar>
         </header>
         <section className="h-fit pt-[132px]">
@@ -89,6 +96,7 @@ export const Component = () => {
           </ul>
         </section>
         <Outlet />
+        <GroupParticipate groupId={groupId} />
       </section>
       <MainNavBar />
     </>

--- a/src/pages/MyGroup.jsx
+++ b/src/pages/MyGroup.jsx
@@ -6,7 +6,7 @@ const MyGroup = ({ groupItems }) => {
   const userInfo = useLoginUserInfo();
 
   return (
-    <section className="mt-[144px]">
+    <section className="mb-16 mt-[144px]">
       <TitleText>{userInfo.nickname}님이 참여 중인 모임이에요</TitleText>
       <ul className="mt-5 grid grid-cols-2 gap-x-5 gap-y-7">
         {groupItems.map((group) => (


### PR DESCRIPTION
### 👀 관련 이슈
#56 모임 상세페이지 - 우리 한 끼

### ✨ 작업한 내용
- 로그인한 사용자가 참여하고 있지 않은 모임의 상세페이지에 접속 시 가입하기 팝업 제공
- 뒤로가기 버튼 추가
- 모임 페이지 하단 마진 추가

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- groupId 이용하여 모임 데이터 불러오기

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
- 하단에 붙이고 싶었는데 dialog로 만드니까 위치 조절이 어려워서 중앙 배치
- 쿼리 사용 실패...

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|모임 가입하기|![image](https://github.com/FRONTENDSCHOOL8/dosirak/assets/148831765/5ccb60e1-94f2-404a-a2fe-3639460a3e84)|
